### PR TITLE
[chore] Remove unused next-auth package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "lucide-react": "0.381.0",
         "memoizee": "0.4.17",
         "next": "14.2.3",
-        "next-auth": "4.24.7",
         "next-mdx-remote": "5.0.0",
         "next-themes": "0.3.0",
         "nextjs-toploader": "1.6.12",
@@ -4111,9 +4110,9 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
     },
     "node_modules/@panva/hkdf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.0.tgz",
-      "integrity": "sha512-97ZQvZJ4gJhi24Io6zI+W7B67I82q1I8i3BSzQ4OyZj1z4OW87/ruF26lrMES58inTKLy2KgVIDcx8PU4AaANQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12476,9 +12475,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.2.tgz",
-      "integrity": "sha512-F1t1/WZJ4JdmCE/XoMYw1dPOW5g8JF0xGm6Ox2fwaCAPlCzt+4Bh0EWP59iQuZNHHauDkCdjx+kCZSh5z/PGow==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12866,17 +12865,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lru-queue": {
@@ -14153,57 +14141,6 @@
         }
       }
     },
-    "node_modules/next-auth": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
-      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
-      },
-      "peerDependencies": {
-        "next": "^12.2.5 || ^13 || ^14",
-        "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18",
-        "react-dom": "^17.0.2 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next-auth/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/next-auth/node_modules/jose": {
-      "version": "4.15.7",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.7.tgz",
-      "integrity": "sha512-L7ioP+JAuZe8v+T5+zVI9Tx8LtU8BL7NxkyDFVMv+Qr3JW0jSoYDedLtodaXwfqMpeCyx4WXFNyu9tJt4WvC1A==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/next-auth/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/next-mdx-remote": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
@@ -14376,11 +14313,6 @@
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
-    },
     "node_modules/oauth4webapi": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.11.1.tgz",
@@ -14395,14 +14327,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -14539,14 +14463,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14567,28 +14483,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openid-client": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
-      "integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
-      "dependencies": {
-        "jose": "^4.15.5",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/jose": {
-      "version": "4.15.7",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.7.tgz",
-      "integrity": "sha512-L7ioP+JAuZe8v+T5+zVI9Tx8LtU8BL7NxkyDFVMv+Qr3JW0jSoYDedLtodaXwfqMpeCyx4WXFNyu9tJt4WvC1A==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -19583,11 +19477,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "lucide-react": "0.381.0",
     "memoizee": "0.4.17",
     "next": "14.2.3",
-    "next-auth": "4.24.7",
     "next-mdx-remote": "5.0.0",
     "next-themes": "0.3.0",
     "nextjs-toploader": "1.6.12",

--- a/src/app/(coming-soon)/coming-soon.tsx
+++ b/src/app/(coming-soon)/coming-soon.tsx
@@ -98,7 +98,7 @@ export function ComingSoon() {
             <li>🌑 ShadCN</li>
             <li>🌈 Tailwind CSS</li>
             <li>📝 Typescript</li>
-            <li>🔒 Authentication (Next-Auth) </li>
+            <li>🔒 Authentication (Lucia-Auth) </li>
             <li>🌐 Google & Github Login </li>
             <li>🔗 Magic Link Login </li>
             <li>👥 Role Based Authorization </li>

--- a/src/app/(landing)/_sections/features.tsx
+++ b/src/app/(landing)/_sections/features.tsx
@@ -46,7 +46,7 @@ export function FeaturesSection() {
             <CodeIcon /> Next.js 14 App Router
           </li>
           <li className={techClass}>
-            <LockIcon /> Authentication with Next-Auth
+            <LockIcon /> Authentication with Lucia-Auth
           </li>
           <li className={techClass}>
             <DollarSignIcon /> One-Off Payments with Stripe

--- a/src/app/(landing)/_sections/the-problem.tsx
+++ b/src/app/(landing)/_sections/the-problem.tsx
@@ -33,7 +33,7 @@ export function TheProblemSection() {
           </p>
 
           <p className={cn(cellClass, "bg-blue-800")}>
-            3. But how will users register? reading through the next-auth docs
+            3. But how will users register? reading through the lucia-auth docs
             sucks. How do I figure out if someone is authenticated AND
             authorized to see that button? 🫠
           </p>

--- a/src/app/conditional-header.tsx
+++ b/src/app/conditional-header.tsx
@@ -16,10 +16,10 @@ import { LogOut, Settings2Icon } from "lucide-react";
 
 import Image from "next/image";
 import { ModeToggle } from "@/components/mode-toggle";
-import { Session } from "next-auth";
 import Link from "next/link";
 import { applicationName } from "@/app-config";
 import { Button } from "@/components/ui/button";
+import { Session } from "lucia";
 
 export function ConditionalHeader({
   session,
@@ -90,7 +90,7 @@ export function ConditionalHeader({
               <DropdownMenu>
                 <DropdownMenuTrigger>
                   <Avatar>
-                    <AvatarImage src={session?.user?.image || undefined} />
+                    {/* <AvatarImage src={session?.user?.image || undefined} /> */}
                     <AvatarFallback>CN</AvatarFallback>
                   </Avatar>
                 </DropdownMenuTrigger>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,8 @@
-// import { getSession } from "next-auth/react";
 import { NextRequest, NextResponse } from "next/server";
 
 export const config = { matcher: ["/dashboard/(.*)"] };
 
 export async function middleware(request: NextRequest) {
-  // const session = await getSession({
-  //   req: {
-  //     ...request,
-  //     headers: {
-  //       ...Object.fromEntries(request.headers),
-  //     },
-  //   },
-  // });
-
-  // const redirectUrl = new URL("/api/auth/signin", request.nextUrl.origin);
-
-  // if (!session || (session.expires && new Date(session.expires) < new Date())) {
-  //   return NextResponse.redirect(redirectUrl);
-  // }
 
   return NextResponse.next();
 }

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -2,7 +2,6 @@
 
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { SessionProvider } from "next-auth/react";
 import { ReactNode } from "react";
 import { ThemeProvider } from "./theme-provider";
 import { env } from "@/env";
@@ -18,7 +17,6 @@ if (typeof window !== "undefined") {
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <RootProvider>
-      {/* <SessionProvider> */}
       <ThemeProvider
         attribute="class"
         defaultTheme="system"
@@ -27,7 +25,6 @@ export function Providers({ children }: { children: ReactNode }) {
       >
         <PostHogProvider client={posthog}>{children}</PostHogProvider>
       </ThemeProvider>
-      {/* </SessionProvider> */}
     </RootProvider>
   );
 }


### PR DESCRIPTION
## [chore] Remove unused next-auth package

Next-Auth is not being used, as Lucia-Auth is the auth library.

Please note: conditional-header.tsx is not being imported in any file. <AvatarImage src={session?.user?.image || undefined} /> was commented since the session does not contain session.user.image. The old Session type was being imported from Next-Auth, which is not the Auth library. To solve this, depending on your goals, I/you can either remove the component, make the component async to be able to get the profile URL or leave it as is.

Next Steps: Good idea to clean up unused packages and make dev dependencies (e.g. "@types/lodash": "4.17.4", "@types/mdx": "2.0.13", "@types/uuid": "9.0.8", etc) be installed as dev dependencies. I can help with that if you want to.


