### PR TITLE
fix: delete user sessions after password change

### DIFF
--- a/src/data-access/sessions.ts
+++ b/src/data-access/sessions.ts
@@ -3,6 +3,6 @@ import { sessions } from "@/db/schema";
 import { UserId } from "@/use-cases/types";
 import { eq } from "drizzle-orm";
 
-export async function deleteSessionForUser(userId: UserId) {
-  await database.delete(sessions).where(eq(sessions.userId, userId));
+export async function deleteSessionForUser(userId: UserId, trx = database) {
+  await trx.delete(sessions).where(eq(sessions.userId, userId));
 }

--- a/src/use-cases/users.tsx
+++ b/src/use-cases/users.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/data-access/notifications";
 import { createTransaction } from "@/data-access/utils";
 import { LoginError } from "./errors";
+import { deleteSessionForUser } from "@/data-access/sessions";
 
 export async function deleteUserUseCase(
   authenticatedUser: UserSession,
@@ -219,6 +220,7 @@ export async function changePasswordUseCase(token: string, password: string) {
   await createTransaction(async (trx) => {
     await deletePasswordResetToken(token, trx);
     await updatePassword(userId, password, trx);
+    await deleteSessionForUser(userId, trx);
   });
 }
 


### PR DESCRIPTION
This PR aims to fix an issue that after password changes the session remains which could be security issue. 
I have modified the `deleteSessionForUser` and introduced an option trx parameter which defaults to `database`.

Also there's use case defined invalidateSessionsUseCase but it's implementation doesn't have transactions so I have directly called the function in the `users.tsx`