### PR TITLE
update following relationship schema

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -241,7 +241,7 @@ export const followingRelationship = relations(following, ({ one }) => ({
   }),
   userProfile: one(profiles, {
     fields: [following.userId],
-    references: [profiles.id],
+    references: [profiles.userId],
   }),
 }));
 


### PR DESCRIPTION
When a user followed someone the 'userProfile' relation wasn't relating correctly to a 'user' record. Perhaps due to the 'user.id' being a primary key.