### PR TITLE
fix clash on conflict when re-sending a reset token

### DIFF
--- a/src/data-access/reset-tokens.ts
+++ b/src/data-access/reset-tokens.ts
@@ -19,7 +19,7 @@ export async function createPasswordResetToken(userId: UserId) {
       tokenExpiresAt,
     })
     .onConflictDoUpdate({
-      target: resetTokens.id,
+      target: resetTokens.userId,
       set: {
         token,
         tokenExpiresAt,


### PR DESCRIPTION
Since the target for `onConflictDoUpdate` on `createPasswordResetToken` was set to `resetToken.id` instead of `resetToken.userId`, if I clicked twice on "Send Reset Email" it would throw an "Duplicate key value violates unique constraints" error instead of refreshing the token in the db.