### PR TITLE
fix(invites): add token expiration column to invites table for proper token expiry check in use-cases/invites.ts

### DIFF
--- a/src/data-access/invites.ts
+++ b/src/data-access/invites.ts
@@ -1,3 +1,4 @@
+import { TOKEN_TTL } from "@/app-config";
 import { database } from "@/db";
 import { GroupId, invites } from "@/db/schema";
 import { eq } from "drizzle-orm";
@@ -13,10 +14,13 @@ export async function deleteInvite(token: string) {
 }
 
 export async function createInvite(groupId: GroupId) {
+  const tokenExpiresAt = new Date(Date.now() + TOKEN_TTL);
+
   const [invite] = await database
     .insert(invites)
     .values({
       groupId,
+      tokenExpiresAt,
     })
     .returning();
   return invite;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,6 +168,7 @@ export const invites = pgTable("gf_invites", {
   groupId: serial("groupId")
     .notNull()
     .references(() => groups.id, { onDelete: "cascade" }),
+  tokenExpiresAt: timestamp("tokenExpiresAt", { mode: "date" }).notNull(),
 });
 
 export const events = pgTable("gf_events", {

--- a/src/use-cases/invites.tsx
+++ b/src/use-cases/invites.tsx
@@ -34,7 +34,7 @@ export async function acceptInviteUseCase(
     throw new PublicError("This invite does not exist or has expired");
   }
 
-  if (invite.tokenExpiresAt! < new Date()) {
+  if (invite.tokenExpiresAt < new Date()) {
     throw new PublicError("This invite has expired");
   }
 


### PR DESCRIPTION
TypeScript throws a type error due to the missing tokenExpiredAt column on the invites table in the schema.ts file