### PR TITLE
refactor: Refactor database configuration to use environment variables for improved flexibility in .env setup and docker-compose

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,13 @@
 # GENERAL
-DATABASE_URL="postgresql://postgres:example@localhost:5432/postgres"
 HOST_NAME="http://localhost:3000"
+
+# DATABASE
+DB_HOST=localhost
+DB_USER=replace_me
+DB_PASSWORD=replace_me
+DB_NAME=replace_me
+DB_PORT=5432
+DB_URL=postgres://${DB_USER}:${DB_PASSWORD}@{DB_HOST}:${DB_PORT}/${DB_NAME}
 
 # GOOGLE OAUTH
 GOOGLE_CLIENT_ID="replace_me"

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ next-env.d.ts
 .env
 
 local.db
+
+docker-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,14 @@
-version: "3.9"
 services:
   wdc-saas-starter-kit:
-    image: postgres
+    image: postgres:16.4
     restart: always
     container_name: wdc-saas-starter-kit
     ports:
-      - 5432:5432
+      - ${DB_PORT}:5432
     environment:
-      POSTGRES_PASSWORD: example
-      PGDATA: /data/postgres
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_DB: ${DB_NAME}
     volumes:
-      - postgres:/data/postgres
-
-volumes:
-  postgres:
+      # this keeps a local version of the database incase the container is ever deleted
+      - ./docker-data/db:/var/lib/postgresql/data

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   dialect: "postgresql",
   out: "./drizzle",
   dbCredentials: {
-    url: env.DATABASE_URL,
+    url: env.DB_URL,
   },
   verbose: true,
   strict: true,

--- a/drizzle/migrate/migrate.ts
+++ b/drizzle/migrate/migrate.ts
@@ -6,7 +6,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
-const pg = postgres(process.env.DATABASE_URL!);
+const pg = postgres(process.env.DB_URL!);
 const database = drizzle(pg);
 
 async function main() {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,11 +7,11 @@ let database: PostgresJsDatabase<typeof schema>;
 let pg: ReturnType<typeof postgres>;
 
 if (env.NODE_ENV === "production") {
-  pg = postgres(env.DATABASE_URL);
+  pg = postgres(env.DB_URL);
   database = drizzle(pg, { schema });
 } else {
   if (!(global as any).database!) {
-    pg = postgres(env.DATABASE_URL);
+    pg = postgres(env.DB_URL);
     (global as any).database = drizzle(pg, { schema });
   }
   database = (global as any).database;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,10 +1,15 @@
-import { createEnv } from "@t3-oss/env-nextjs";
-import { z } from "zod";
+import { createEnv } from '@t3-oss/env-nextjs';
+import { z } from 'zod';
 
 export const env = createEnv({
   server: {
-    DATABASE_URL: z.string().min(1),
     NODE_ENV: z.string().optional(),
+    DB_HOST: z.string().min(1),
+    DB_USER: z.string().min(1),
+    DB_PASSWORD: z.string().min(1),
+    DB_NAME: z.string().min(1),
+    DB_PORT: z.string().min(1),
+    DB_URL: z.string().min(1),
     GOOGLE_CLIENT_ID: z.string().min(1),
     GOOGLE_CLIENT_SECRET: z.string().min(1),
     STRIPE_API_KEY: z.string().min(1),
@@ -33,7 +38,12 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    DATABASE_URL: process.env.DATABASE_URL,
+    DB_HOST: process.env.DB_HOST,
+    DB_USER: process.env.DB_USER,
+    DB_PASSWORD: process.env.DB_PASSWORD,
+    DB_NAME: process.env.DB_NAME,
+    DB_PORT: process.env.DB_PORT,
+    DB_URL: process.env.DB_URL,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     STRIPE_API_KEY: process.env.STRIPE_API_KEY,


### PR DESCRIPTION
The main change here is with the docker compose file and updating the `.env.example` file. 

With this change we are now able to keep the database within the repo of the project locally and not inside the container, incase for whatever reason a container or volume is deleted. 

I updated `DATABASE_URL` to `DB_URL` for consistency with this setup. Feel free to change this if needed. 

Also apologies I just noticed my formatter changed the import paths from double to single quotes in the `src/env.ts` file. 