### PR TITLE
Fix: Navbar User State Not Updating After Login/Registration

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -54,5 +54,5 @@ export const assertAuthenticated = async () => {
 export async function setSession(userId: UserId) {
   const token = generateSessionToken();
   const session = await createSession(token, userId);
-  setSessionTokenCookie(token, session.expiresAt);
+  await setSessionTokenCookie(token, session.expiresAt);
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -12,7 +12,7 @@ export async function setSessionTokenCookie(
   expiresAt: Date
 ): Promise<void> {
   const allCookies = await cookies();
-  await allCookies.set(SESSION_COOKIE_NAME, token, {
+  allCookies.set(SESSION_COOKIE_NAME, token, {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
@@ -23,7 +23,7 @@ export async function setSessionTokenCookie(
 
 export async function deleteSessionTokenCookie(): Promise<void> {
   const allCookies = await cookies();
-  await allCookies.set(SESSION_COOKIE_NAME, "", {
+  allCookies.set(SESSION_COOKIE_NAME, "", {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
This PR resolves an issue where the navbar does not update to reflect the user's logged-in state after successful login or registration. The problem occurs when using email and password for authentication.

---

### Steps to Reproduce the Issue

1. Navigate to the **Login** or **Sign-Up** page (email and password).
2. Enter valid credentials and press **Submit**.
3. Observe that the navbar still displays the "Sign In" option instead of the user's logged-in state.
4. In some cases, the page gets stuck on the login or sign-up screen after submission.

---

![Pasted image 20241220093554](https://github.com/user-attachments/assets/4e6357c0-303e-4f09-83f0-5f9bc7ab0f93)
