### PR TITLE
Fix: Correct table reference in invalidateUserSessions

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -98,7 +98,7 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 
 export async function invalidateUserSessions(userId: UserId): Promise<void> {
-  await database.delete(sessions).where(eq(users.id, userId));
+  await database.delete(sessions).where(eq(sessions.userId, userId));
 }
 
 export type SessionValidationResult =


### PR DESCRIPTION
### Fix: Correct table reference in `invalidateUserSessions`

This pull request resolves a `PostgresError: missing FROM-clause entry for table "gf_user"` that occurred when a user signs out from all devices.

The `invalidateUserSessions` function was incorrectly referencing the `users` table in the `WHERE` clause (`eq(users.id, userId)`). The query only selects from the `sessions` table, so this reference was invalid.

This change updates the query to reference the `userId` column on the `sessions` table (`eq(sessions.userId, userId)`), which resolves the database error.